### PR TITLE
Deploying precompiled binary instead of source to Elastic Beanstalk

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior for line endings
+* text=auto

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - *
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,9 @@ on:
   push:
     branches:
       - master
-  pull_request
+  pull_request:
+    branches:
+      - *
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,12 @@
 name: Deploy master
 
+# Execute workflow on push to master or on any pull request
+# Job to deploy to prod will only execute for master branch
 on: 
   push:
-    branches: [ master ]
+    branches:
+      - master
+  pull_request
 
 jobs:
   build:
@@ -14,29 +18,56 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: '1.14'
+
+    # Compile application to binary at bin/application
     - name: Build
-      run: |
-        ./build.sh
+      run: go build -o bin/application .
+
+    # Pack compiled binary into zip file
     - name: Pack
-      run: |
-        git archive -o source.zip HEAD
+      run: zip source.zip bin/application
+
+    # Upload build artifact for consumption by subsequent deploy jobs
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:
         name: deployable
         path: source.zip
 
-  deploy:
+  deploy-dev:
     runs-on: ubuntu-latest
     needs: [ build ]
-    
+
     steps:
     - name: Download build artifact
       uses: actions/download-artifact@v1
       with:
         name: deployable
     - name: Deploy to Elastic Beanstalk
-      uses: einaregilsson/beanstalk-deploy@verboselog
+      uses: einaregilsson/beanstalk-deploy@v8
+      with:
+        aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        application_name: MatterhornApiService
+        environment_name: Matterhornapiservice-env-dev
+        version_label: ${{ github.run_id }}
+        region: ${{ secrets.AWS_REGION }}
+        deployment_package: ./deployable/source.zip
+
+  deploy-prod:
+    # Only run this job on master
+    if: github.ref == 'refs/heads/master'
+
+    runs-on: ubuntu-latest
+    needs: [ build, deploy-dev ]
+
+    steps:
+    - name: Download build artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: deployable
+    - name: Deploy to Elastic Beanstalk
+      uses: einaregilsson/beanstalk-deploy@v8
       with:
         aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
         version_label: ${{ github.run_id }}
         region: ${{ secrets.AWS_REGION }}
         deployment_package: ./deployable/source.zip
+        use_existing_version_if_available: true
 
   deploy-prod:
     # Only run this job on master
@@ -76,3 +77,4 @@ jobs:
         version_label: ${{ github.run_id }}
         region: ${{ secrets.AWS_REGION }}
         deployment_package: ./deployable/source.zip
+        use_existing_version_if_available: true

--- a/Buildfile
+++ b/Buildfile
@@ -1,1 +1,0 @@
-make: ./build.sh

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bin/application

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,2 @@
 # https://stackoverflow.com/questions/59144120/gopath-go-mod-exists-but-should-not-in-aws-elastic-beanstalk
 sudo rm /var/app/current/go.*
-
-go build -o bin/application .

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-# https://stackoverflow.com/questions/59144120/gopath-go-mod-exists-but-should-not-in-aws-elastic-beanstalk
-sudo rm /var/app/current/go.*


### PR DESCRIPTION
Updated the github actions CI/CD configuration to execute on push to master OR on pull request for any branch. Deployment to the dev environment will always occur on a successful build; deployment to the prod environment will only occur on a push to master following a successful build and successful deployment to the dev environment.

Updated the CI/CD configuration to build the application and then package the compiled binary in a zip file, instead of packing up the whole repository and relying on the host to compile during deployment. 

Adding .gitattributes to define line endings configuration across platforms.