### PR TITLE
Adding first unit tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
     - name: Build
       run: |
         ./build.sh
+    - name: Test
+      run: go test
     - name: Pack
       run: |
         git archive -o source.zip HEAD

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
     
     # Execute unit tests
     - name: Test
+      env:
+        MATTERHORN_DB_ENDPOINT: ${{ secrets.MATTERHORN_DB_ENDPOINT }}
+        MATTERHORN_DB_PASSWORD: ${{ secrets.MATTERHORN_DB_PASSWORD }}
       run: go test
 
     # Pack compiled binary into zip file

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 # Compiled artifacts
 bin
 
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ MatterhornApiService expects to connect to a MySQL-compatible database instance.
 ### Run
 `go run`
 
+### Unit Tests
+`go test`
+
 ## CI/CD
 
 MatterhornApiService is configured to deploy to AWS Elastic Beanstalk. `Buildfile`, and `Procfile` are provided to describe how to run and build the application to Elastic Beanstalk. Before running the application, Elastic Beanstalk will execute the `build.sh` script; this is done instead of deploying a pre-compiled binary because it needs to be compiled for the OS and architecture of the target host.

--- a/database_test.go
+++ b/database_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDbConnect(t *testing.T) {
+	// Attempt to connect to the database
+	db, err := DbConnect()
+	if err != nil {
+		t.Errorf("Failed to connect to database: %s", err.Error())
+	}
+
+	// Attempt to ping the database to make sure we actually established a connection
+	err = db.Ping()
+	if err != nil {
+		t.Errorf("Failed to connect to database: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Adding database_test.go test file with unit test exercising DbConnect function.
Updating github workflow to execute unit tests during build job.