### PR TITLE
Bug: .env files excluded from deployed package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
     # Compile application to binary at bin/application
     - name: Build
-      run: go build -o bin/application .
+      run: go build -o application .
     
     # Execute unit tests
     - name: Test
@@ -32,7 +32,7 @@ jobs:
 
     # Pack compiled binary into zip file
     - name: Pack
-      run: zip source.zip bin/application
+      run: zip source.zip application .env*
 
     # Upload build artifact for consumption by subsequent deploy jobs
     - name: Upload build artifact

--- a/environment.go
+++ b/environment.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -16,8 +17,14 @@ func LoadEnv() {
 	}
 
 	// Environment-specific configuration
-	godotenv.Load(".env." + env)
+	err := godotenv.Load(".env." + env)
+	if err != nil {
+		log.Fatalf("Failed to load configuration from .env.%s: %v", env, err)
+	}
 
 	// Global configuration (lower priority)
-	godotenv.Load()
+	err = godotenv.Load()
+	if err != nil {
+		log.Fatalf("Failed to load configuration from .env: %v", err)
+	}
 }


### PR DESCRIPTION
Updating 'deploy' workflow to include .env* files.
Updating 'deploy' workflow to pack application binary in the root of the
zip so that its location is consistent relative to the .env* files in
the local and deployed environments.