### PR TITLE
Adding tasks to start mysql-server in Docker and local DB configuration

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+MATTERHORN_DB_ENDPOINT=localhost:3306
+MATTERHORN_DB_NAME=MatterhornDb_Local

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
       env:
         MATTERHORN_DB_ENDPOINT: ${{ secrets.MATTERHORN_DB_ENDPOINT }}
         MATTERHORN_DB_PASSWORD: ${{ secrets.MATTERHORN_DB_PASSWORD }}
+        MATTERHORN_ENV: dev
       run: go test
 
     # Pack compiled binary into zip file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
     # Execute unit tests
     - name: Test
       env:
-        MATTERHORN_DB_ENDPOINT: ${{ secrets.MATTERHORN_DB_ENDPOINT }}
         MATTERHORN_DB_PASSWORD: ${{ secrets.MATTERHORN_DB_PASSWORD }}
         MATTERHORN_ENV: dev
       run: go test

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,36 @@
             "label": "Run Server",
             "type": "shell",
             "command": "go run ."
+        },
+        {
+            "label": "Dev Database - Migrate",
+            "type": "shell",
+            "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(matterhorn-database-instance.cll2j98hq3ha.us-east-1.rds.amazonaws.com:3306)/MatterhornDb_Dev?multiStatements=true' up"
+        },
+        {
+            "label": "Dev Database - Rollback",
+            "type": "shell",
+            "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(matterhorn-database-instance.cll2j98hq3ha.us-east-1.rds.amazonaws.com:3306)/MatterhornDb_Dev?multiStatements=true' down 1"
+        },
+        {
+            "label": "Local Database - Migrate",
+            "type": "shell",
+            "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(localhost:3306)/MatterhornDb_Local?multiStatements=true' up"
+        },
+        {
+            "label": "Local Database - Rollback",
+            "type": "shell",
+            "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(localhost:3306)/MatterhornDb_Local?multiStatements=true' down 1"
+        },
+        {
+            "label": "Local Database - Start",
+            "type": "shell",
+            "command": "docker run -d -p 3306:3306 --name=mysql-server -e MYSQL_USER=admin -e MYSQL_PASSWORD=${env:MATTERHORN_DB_PASSWORD} -e MYSQL_DATABASE=MatterhornDb_Local -e MYSQL_RANDOM_ROOT_PASSWORD=1 mysql"
+        },
+        {
+            "label": "Local Database - Kill/Remove",
+            "type": "shell",
+            "command": "docker rm -f mysql-server"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
             "label": "Pack",
             "type": "shell",
             "command": "go build -o bin/application ."
-        }
+        },
         {
             "label": "Clean",
             "type": "shell",
@@ -27,16 +27,19 @@
             "type": "shell",
             "command": "go run ."
         },
-        {
-            "label": "Dev Database - Migrate",
-            "type": "shell",
-            "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(matterhorn-database-instance.cll2j98hq3ha.us-east-1.rds.amazonaws.com:3306)/MatterhornDb_Dev?multiStatements=true' up"
-        },
-        {
-            "label": "Dev Database - Rollback",
-            "type": "shell",
-            "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(matterhorn-database-instance.cll2j98hq3ha.us-east-1.rds.amazonaws.com:3306)/MatterhornDb_Dev?multiStatements=true' down 1"
-        },
+
+        // These tasks are power tools for manually fixing issues in our cloud-deployed development database.
+        // {
+        //     "label": "Dev Database - Migrate",
+        //     "type": "shell",
+        //     "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(matterhorn-database-instance.cll2j98hq3ha.us-east-1.rds.amazonaws.com:3306)/MatterhornDb_Dev?multiStatements=true' up"
+        // },
+        // {
+        //     "label": "Dev Database - Rollback",
+        //     "type": "shell",
+        //     "command": "migrate -source file://./migrations -database 'mysql://admin:${env:MATTERHORN_DB_PASSWORD}@tcp(matterhorn-database-instance.cll2j98hq3ha.us-east-1.rds.amazonaws.com:3306)/MatterhornDb_Dev?multiStatements=true' down 1"
+        // },
+
         {
             "label": "Local Database - Migrate",
             "type": "shell",

--- a/environment.go
+++ b/environment.go
@@ -12,8 +12,8 @@ import (
 func LoadEnv() {
 	env := os.Getenv("MATTERHORN_ENV")
 	if "" == env {
-		// Default to "development"
-		env = "dev"
+		// Default to "local"
+		env = "local"
 	}
 
 	// Environment-specific configuration


### PR DESCRIPTION
Adding VSCode tasks to start or kill/remove a local mysql-server instance running in Docker.
Adding new 'local' environment configuration and updating environment.go to make this the new default in the absence of an explicitly defined MATTERHORN_ENV.
With these changes we will be able to easily spin up a local database running in a Docker container and use it for local development and testing.