### PR TITLE
Adding database migration for adding test user data to database

### DIFF
--- a/migrations/3_insert_TestUser.down.sql
+++ b/migrations/3_insert_TestUser.down.sql
@@ -1,0 +1,13 @@
+DELETE FROM Users WHERE UserID=1;
+
+ALTER TABLE FoodRecords
+    DROP FOREIGN KEY fk_FoodRecords_UserID,
+    ADD FOREIGN KEY (UserID) REFERENCES Users(UserID);
+
+ALTER TABLE ExerciseRecords
+    DROP FOREIGN KEY fk_ExerciseRecords_UserID,
+    ADD FOREIGN KEY (UserID) REFERENCES Users(UserID);
+
+ALTER TABLE CalorieGoals
+    DROP FOREIGN KEY fk_CalorieGoals_UserID,
+    ADD FOREIGN KEY (UserID) REFERENCES Users(UserID);

--- a/migrations/3_insert_TestUser.up.sql
+++ b/migrations/3_insert_TestUser.up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE CalorieGoals 
+    DROP FOREIGN KEY CalorieGoals_ibfk_1,
+    ADD CONSTRAINT fk_CalorieGoals_UserID FOREIGN KEY (UserID)
+        REFERENCES Users(UserID)
+        ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE ExerciseRecords 
+    DROP FOREIGN KEY ExerciseRecords_ibfk_1,
+    ADD CONSTRAINT fk_ExerciseRecords_UserID FOREIGN KEY (UserID)
+        REFERENCES Users(UserID)
+        ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE FoodRecords 
+    DROP FOREIGN KEY FoodRecords_ibfk_1,
+    ADD CONSTRAINT fk_FoodRecords_UserID FOREIGN KEY (UserID)
+        REFERENCES Users(UserID)
+        ON UPDATE CASCADE ON DELETE CASCADE;
+
+INSERT INTO Users (UserID, DisplayName, Age, Height, Weight, Sex) 
+VALUES (1, "Test User", 23, 68, 160.5, 'Male')
+ON DUPLICATE KEY UPDATE DisplayName='Test User', Age=23, Height=68, Weight=160.5, Sex='Male';


### PR DESCRIPTION
Adding database migration that adds a row of test data to the Users database.
This migration also recreates the foreign key constraints on existing database tables
to define 'CASCADE' behavior in response to an update or delete of the row associated
with the foreign key.
This means that if a User row is deleted, then all rows in other tables with
a foreign key relationship to that User are also deleted.
If a user row's ID is updated, then all rows in other tables that currently map
to that row will have their foreign key values updated to maintain the relationship.
Previously, these updates did not "cascade", which meant that attempts to delete
a row from the Users table would simply fail if it would result in a violated foreign
key relationship (data associated with the User row in another table would have
foreign key values corresponding to nothing).