### PR TITLE
Replacing POC database tables with MVP tables

### DIFF
--- a/migrations/4_drop_PoC_Tables.down.sql
+++ b/migrations/4_drop_PoC_Tables.down.sql
@@ -1,0 +1,68 @@
+CREATE TABLE IF NOT EXISTS Counters (
+  ID int,
+  Value int,
+  PRIMARY KEY (ID)
+);
+
+INSERT IGNORE INTO Counters(ID, Value)
+VALUES(1, 0);
+
+CREATE TABLE IF NOT EXISTS Users (
+  UserID int,
+  DisplayName VARCHAR(50),
+  Age int,
+  Height int,
+  Sex ENUM('Female', 'Male'),
+  Weight int,
+  PRIMARY KEY (UserID)
+);
+
+CREATE TABLE IF NOT EXISTS CalorieGoals (
+    ID int AUTO_INCREMENT,
+    UserID int NOT NULL,
+    Calories int NOT NULL,
+    PRIMARY KEY (ID),
+    FOREIGN KEY (UserID) REFERENCES Users(UserID)
+);
+
+CREATE TABLE IF NOT EXISTS ExerciseRecords (
+    ID int AUTO_INCREMENT,
+    UserID int NOT NULL,
+    Calories int NOT NULL,
+    Label VARCHAR(255) DEFAULT '',
+    Timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (ID),
+    FOREIGN KEY (UserID) REFERENCES Users(UserID)
+);
+
+CREATE TABLE IF NOT EXISTS FoodRecords (
+    ID int AUTO_INCREMENT,
+    UserID int NOT NULL,
+    Calories int NOT NULL,
+    Label VARCHAR(255) DEFAULT '',
+    Timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (ID),
+    FOREIGN KEY (UserID) REFERENCES Users(UserID)
+);
+
+ALTER TABLE CalorieGoals 
+    DROP FOREIGN KEY CalorieGoals_ibfk_1,
+    ADD CONSTRAINT fk_CalorieGoals_UserID FOREIGN KEY (UserID)
+        REFERENCES Users(UserID)
+        ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE ExerciseRecords 
+    DROP FOREIGN KEY ExerciseRecords_ibfk_1,
+    ADD CONSTRAINT fk_ExerciseRecords_UserID FOREIGN KEY (UserID)
+        REFERENCES Users(UserID)
+        ON UPDATE CASCADE ON DELETE CASCADE;
+
+ALTER TABLE FoodRecords 
+    DROP FOREIGN KEY FoodRecords_ibfk_1,
+    ADD CONSTRAINT fk_FoodRecords_UserID FOREIGN KEY (UserID)
+        REFERENCES Users(UserID)
+        ON UPDATE CASCADE ON DELETE CASCADE;
+
+INSERT INTO Users (UserID, DisplayName, Age, Height, Weight, Sex) 
+VALUES (1, "Test User", 23, 68, 160.5, 'Male')
+ON DUPLICATE KEY UPDATE DisplayName='Test User', Age=23, Height=68, Weight=160.5, Sex='Male';

--- a/migrations/4_drop_PoC_Tables.up.sql
+++ b/migrations/4_drop_PoC_Tables.up.sql
@@ -1,0 +1,5 @@
+DROP TABLE Counters;
+DROP TABLE FoodRecords;
+DROP TABLE ExerciseRecords;
+DROP TABLE CalorieGoals;
+DROP TABLE Users;

--- a/migrations/5_create_MVP_Tables.down.sql
+++ b/migrations/5_create_MVP_Tables.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE food_records;
+DROP TABLE exercise_records;
+DROP TABLE users;

--- a/migrations/5_create_MVP_Tables.up.sql
+++ b/migrations/5_create_MVP_Tables.up.sql
@@ -12,6 +12,7 @@ CREATE TABLE users (
 CREATE TABLE exercise_records (
     PRIMARY KEY (exercise_record_id),
     FOREIGN KEY (user_id) REFERENCES users(user_id),
+    user_id                 VARCHAR(255)                        NOT NULL,
     exercise_record_id      INT UNSIGNED AUTO_INCREMENT         NOT NULL,
     calories                INT UNSIGNED                        NOT NULL,
     label                   VARCHAR(255),
@@ -21,6 +22,7 @@ CREATE TABLE exercise_records (
 CREATE TABLE food_records (
     PRIMARY KEY (food_record_id),
     FOREIGN KEY (user_id) REFERENCES users(user_id),
+    user_id                 VARCHAR(255)                        NOT NULL,
     food_record_id          INT UNSIGNED AUTO_INCREMENT         NOT NULL,
     calories                INT UNSIGNED                        NOT NULL,
     label                   VARCHAR(255),

--- a/migrations/5_create_MVP_Tables.up.sql
+++ b/migrations/5_create_MVP_Tables.up.sql
@@ -1,0 +1,28 @@
+CREATE TABLE users (
+    PRIMARY KEY (user_id),
+    user_id         VARCHAR(255)            NOT NULL,
+    age             INT UNSIGNED            NOT NULL,
+    calorie_goal    INT UNSIGNED            NOT NULL,
+    display_name    VARCHAR(255)            NOT NULL,
+    height_inches   INT UNSIGNED            NOT NULL,
+    sex             ENUM('Female', 'Male')  NOT NULL,
+    weight_pounds   INT UNSIGNED            NOT NULL
+);
+
+CREATE TABLE exercise_records (
+    PRIMARY KEY (exercise_record_id),
+    FOREIGN KEY (user_id) REFERENCES users(user_id),
+    exercise_record_id      INT UNSIGNED AUTO_INCREMENT         NOT NULL,
+    calories                INT UNSIGNED                        NOT NULL,
+    label                   VARCHAR(255),
+    timestamp               TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE TABLE food_records (
+    PRIMARY KEY (food_record_id),
+    FOREIGN KEY (user_id) REFERENCES users(user_id),
+    food_record_id          INT UNSIGNED AUTO_INCREMENT         NOT NULL,
+    calories                INT UNSIGNED                        NOT NULL,
+    label                   VARCHAR(255),
+    timestamp               TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);


### PR DESCRIPTION
Adding database migrations to drop existing POC database tables and
replace them with new database tables that we will use to build the MVP.
This change is motivated primarily by the need to switch from an integer
to a varchar data type for the PRIMARY key on the Users table; altering
a data type of a column that is also a foreign key for other tables was
complicated enough that it seemed better to just take the opportunity
to redesign the tables entirely.

#25 